### PR TITLE
Use extend() to merge lists; append() only works with single elements

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -434,7 +434,7 @@ def main_loop(args):
         # add tags to "tags_to_keep" list, if we have regexp "tags_to_keep" entries:
         keep_tags=[]
         if args.keep_tags_like:
-            keep_tags.append(get_tags_like(args.keep_tags_like, tags_list))
+            keep_tags.extend(get_tags_like(args.keep_tags_like, tags_list))
 
 
         # delete tags if told so


### PR DESCRIPTION
When we use --keep-tags-like with wildcards, get_tags_like() returns a set. When we append() that set to keep_tags, we get a mess:
"Getting digest for tag set([u'8.16.1-RC-SNAPSHOT-6', u'8.16.1-RC-SNAPSHOT-5'])
  tag digest not found: 404
Tag set([u'8.16.1-RC-SNAPSHOT-6', u'8.16.1-RC-SNAPSHOT-5']) does not exist for image iscp/isc. Ignore here."
As a result, the tags we want to keep get ignored.

Changing append() to extend() corrects the issue.