### PR TITLE
Keep by hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ registry.py is a script for easy manipulation of docker-registry from command li
 * [Installation](#installation)
   * [Docker image](#docker-image)
   * [Python script](#python-script)
-* [Listing images](#listing-images) 
+* [Listing images](#listing-images)
 * [Username and password](#username-and-password)
 * [Deleting images](#deleting-images)
 * [Disable ssl verification](#disable-ssl-verification)
@@ -113,7 +113,7 @@ The following command would delete all tags containing "snapshot-" and beginning
 
 As one manifest may be referenced by more than one tag, you may add tags, whose manifests should NOT be deleted.
 A tag that would otherwise be deleted, but whose manifest references one of those "kept" tags, is spared for deletion.
-In the following case, all tags beginning with "snapshot-" will be deleted, safe those whose manifest point to "stable" or "latest"
+In the following case, all tags beginning with "snapshot-" will be deleted, save those whose manifest point to "stable" or "latest":
 
 ```
   registry.py -l user:pass -r https://example.com:5000 --delete --tags-like "snapshot-" --keep-tags "stable" "latest"
@@ -134,6 +134,11 @@ Delete all tags for all images (do you really want to do it?):
 Delete all tags by age in hours for the particular image (e.g. older than 24 hours, with --keep-tags and --keep-tags-like options, --dry-run for safe).
 ```
   registry.py -r https://example.com:5000 -i api-docs-origin/master --dry-run --delete-by-hours 24 --keep-tags c59c02c25f023263fd4b5d43fc1ff653f08b3d4x --keep-tags-like late
+```
+
+Note that deleting by age will not prevent more recent tags from being deleted if there are more than 10 (or specified `--num` value). In order to keep all tags within a designated period, use the `--keep-by-hours` flag:
+```
+  registry.py -r https://example.com:5000 --dry-run --delete --keep-by-hours 72 --keep-tags-like latest
 ```
 ## Disable ssl verification
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ In the following case, all tags beginning with "snapshot-" will be deleted, save
 ```
   registry.py -l user:pass -r https://example.com:5000 --delete --tags-like "snapshot-" --keep-tags "stable" "latest"
 ```
-The last parameter is also available as regexp option with "--keep-tags-like".
+The last parameter is also available as regexp option with `--keep-tags-like`.
 
 
 Delete all tags for particular image (e.g. delete all ubuntu tags):
@@ -131,7 +131,7 @@ Delete all tags for all images (do you really want to do it?):
   registry.py -l user:pass -r https://example.com:5000 --delete-all --dry-run
 ```
 
-Delete all tags by age in hours for the particular image (e.g. older than 24 hours, with --keep-tags and --keep-tags-like options, --dry-run for safe).
+Delete all tags by age in hours for the particular image (e.g. older than 24 hours, with `--keep-tags` and `--keep-tags-like` options, `--dry-run` for safe).
 ```
   registry.py -r https://example.com:5000 -i api-docs-origin/master --dry-run --delete-by-hours 24 --keep-tags c59c02c25f023263fd4b5d43fc1ff653f08b3d4x --keep-tags-like late
 ```
@@ -149,7 +149,7 @@ If you are using docker registry with a self signed ssl certificate, you can dis
 
 ## Nexus docker registry
 
-Add --digest-method flag
+Add `--digest-method` flag
 
 ```
 registry.py -l user:pass -r https://example.com:5000 --digest-method GET


### PR DESCRIPTION
This PR adds a flag, `--keep by hours`, which allows specifying a time period for which no tags should be deleted.

When running the tool on a registry, my `--keep-like` matches would exceed 10, but I also wanted to keep _any_ tag that was less than 90 days old. This was my solution. I've also added some tests and updated the README. There are also a few small stylistic changes to the README (standardizing that any mention of flags should be plaintext), and I fixed one typo I found. My editor also removes unnecessary spaces at EOL or blank lines, which is PEP8 compliant, so I left those changes in as well.