### PR TITLE
select images with regex and be fast

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -13,6 +13,7 @@ import argparse
 import www_authenticate
 from datetime import timedelta, datetime as dt
 from getpass import getpass
+from multiprocessing.pool import ThreadPool
 
 # this is a registry manipulator, can do following:
 # - list all images (including layers)
@@ -550,11 +551,20 @@ def delete_tags(
 
             keep_tag_digests.append(digest)
 
+    def delete(tag):
+        print("  deleting tag {0}".format(tag))
+        registry.delete_tag(image_name, tag, dry_run, keep_tag_digests)
+
+    p = ThreadPool(4)
+    tasks = []
     for tag in tags_to_delete:
         if tag in tags_to_keep:
             continue
-
-        print("  deleting tag {0}".format(tag))
+        tasks.append(p.apply_async(delete, args=(tag,)))
+    for task in tasks:
+        task.get()
+    p.close()
+    p.join()
 
 # deleting layers is disabled because
 # it also deletes shared layers
@@ -562,8 +572,6 @@ def delete_tags(
 # for layer in registry.list_tag_layers(image_name, tag):
 # layer_digest = layer['digest']
 # registry.delete_tag_layer(image_name, layer_digest, dry_run)
-
-        registry.delete_tag(image_name, tag, dry_run, keep_tag_digests)
 
 
 def get_tags_like(args_tags_like, tags_list):
@@ -620,27 +628,30 @@ def delete_tags_by_age(registry, image_name, dry_run, hours, tags_to_keep):
 
 
 def get_newer_tags(registry, image_name, hours, tags_list):
-    newer_tags = []
-    print('---------------------------------')
-    for tag in tags_list:
+    def newer(tag):
         image_config = registry.get_tag_config(image_name, tag)
-
         if image_config == []:
             print("tag not found")
-            continue
-
+            return None
         image_age = registry.get_image_age(image_name, image_config)
-
         if image_age == []:
             print("timestamp not found")
-            continue
-
+            return None
         if dt.strptime(image_age[:-4], "%Y-%m-%dT%H:%M:%S.%f") >= dt.now() - timedelta(hours=int(hours)):
             print("Keeping tag: {0} timestamp: {1}".format(
                 tag, image_age))
-            newer_tags.append(tag)
+            return tag
+        else:
+            print("Will delete tag: {0} timestamp: {1}".format(
+                tag, image_age))
+            return None
 
-    return newer_tags
+    print('---------------------------------')
+    p = ThreadPool(4)
+    result = list(x for x in p.map(newer, tags_list) if x)
+    p.close()
+    p.join()
+    return result
 
 
 def keep_images_like(image_list, regexp_list):

--- a/registry.py
+++ b/registry.py
@@ -458,6 +458,13 @@ for more detail on garbage collection read here:
         metavar="IMAGE:[TAG]")
 
     parser.add_argument(
+        '--images-like',
+        nargs='+',
+        help="List of images (regexp check) that will be handled",
+        required=False,
+        default=[])
+
+    parser.add_argument(
         '--keep-tags',
         nargs='+',
         help="List of tags that will be omitted from deletion if used in combination with --delete or --delete-all",
@@ -636,6 +643,17 @@ def get_newer_tags(registry, image_name, hours, tags_list):
     return newer_tags
 
 
+def keep_images_like(image_list, regexp_list):
+    result = []
+    regexp_list = list(map(re.compile, regexp_list))
+    for image in image_list:
+        for regexp in regexp_list:
+            if re.search(regexp, image):
+                result.append(image)
+                break
+    return result
+
+
 def main_loop(args):
     global DEBUG
 
@@ -685,6 +703,8 @@ def main_loop(args):
         image_list = args.image
     else:
         image_list = registry.list_images()
+        if args.images_like:
+            image_list = keep_images_like(image_list, args.images_like)
 
     # loop through registry's images
     # or through the ones given in command line


### PR DESCRIPTION
Hello,

I'm creating one PR hoping you'll like both commits. They have no dependency on each other.

The first one adds `--images-like` so one can filter images with a regular expression. I needed this option so I added it.

The second one uses ThreadPools for searching and deleting. These computations are network-bound and running them concurrently speeds up the whole process by a large factor. Using more than 4 threads yielded no further benefits here but your mileage may vary. Using processes is useless since as I said the computation is network bound. You can try if you want to try it yourself but as the code stands you'll need to pull in the `multiprocess` module in order to copy objects into a new process.