### PR TITLE
fix time.strptime thread safe problem

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -11,6 +11,7 @@ import sys
 import os
 import argparse
 import www_authenticate
+import _strptime
 from datetime import timedelta, datetime as dt
 from getpass import getpass
 from multiprocessing.pool import ThreadPool


### PR DESCRIPTION
fix #53 

also see https://stackoverflow.com/questions/2427240/thread-safe-equivalent-to-pythons-time-strptime

@andrey-pohilko 