### PR TITLE
Fix wrong name of argument.

### DIFF
--- a/test.py
+++ b/test.py
@@ -846,7 +846,7 @@ class TestArgParser(unittest.TestCase):
                      "--delete-by-hours", "24",
                      "--keep-by-hours", "24",
                      "--digest-method", "GET",
-                     "--order-by-age"]
+                     "--order-by-date"]
         args = parse_args(args_list)
         self.assertTrue(args.delete)
         self.assertTrue(args.layers)


### PR DESCRIPTION
Fixes a failing test in https://github.com/andrey-pohilko/registry-cli/pull/73. I renamed the option, but forgot to rename it everywhere.