### PR TITLE
Dateparsing code crashes on non-UTC datetimes. 

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -11,10 +11,11 @@ import sys
 import os
 import argparse
 import www_authenticate
-import _strptime
 from datetime import timedelta, datetime as dt
 from getpass import getpass
 from multiprocessing.pool import ThreadPool
+from dateutil.parser import parse
+from dateutil.tz import tzutc
 
 # this is a registry manipulator, can do following:
 # - list all images (including layers)
@@ -642,7 +643,7 @@ def delete_tags_by_age(registry, image_name, dry_run, hours, tags_to_keep):
             print("timestamp not found")
             continue
 
-        if dt.strptime(image_age[:-4], "%Y-%m-%dT%H:%M:%S.%f") < dt.now() - timedelta(hours=int(hours)):
+        if parse(image_age).astimezone(tzutc()) < dt.now(tzutc()) - timedelta(hours=int(hours)):
             print("will be deleted tag: {0} timestamp: {1}".format(
                 tag, image_age))
             tags_to_delete.append(tag)
@@ -661,7 +662,7 @@ def get_newer_tags(registry, image_name, hours, tags_list):
         if image_age == []:
             print("timestamp not found")
             return None
-        if dt.strptime(image_age[:-4], "%Y-%m-%dT%H:%M:%S.%f") >= dt.now() - timedelta(hours=int(hours)):
+        if parse(image_age).astimezone(tzutc()) >= dt.now(tzutc()) - timedelta(hours=int(hours)):
             print("Keeping tag: {0} timestamp: {1}".format(
                 tag, image_age))
             return tag
@@ -690,7 +691,7 @@ def get_datetime_tags(registry, image_name, tags_list):
             return None
         return {
             "tag": tag,
-            "datetime": dt.strptime(image_age[:-4], "%Y-%m-%dT%H:%M:%S.%f")
+            "datetime": parse(image_age).astimezone(tzutc())
         }
 
     print('---------------------------------')

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,7 @@
 certifi==2017.7.27.1
 chardet==3.0.4
 idna>=2.5
+python-dateutil==2.8.0
 requests>=2.20.0
 urllib3>=1.23
 www-authenticate==0.9.2


### PR DESCRIPTION
Use python-dateutil for parsing dates, then convert them to UTC.

Closes https://github.com/andrey-pohilko/registry-cli/issues/75