### PR TITLE
Fix use of IMAGE:TAG syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Note that deleting by age will not prevent more recent tags from being deleted i
 ```
   registry.py -r https://example.com:5000 --dry-run --delete --keep-by-hours 72 --keep-tags-like latest
 ```
+
+Alternative method of deleting an explicit tag of an image:
+```
+  registry.py -r https://example.com:5000 --dry-run --delete --num 0 --image example:latest
+```
+
 ## Disable ssl verification
 
 If you are using docker registry with a self signed ssl certificate, you can disable ssl verification:

--- a/registry.py
+++ b/registry.py
@@ -796,7 +796,8 @@ def main_loop(args):
             (image_name, tag_name) = image_name.split(":")
             all_tags_list = registry.list_tags(image_name)
             if not tag_name in all_tags_list:
-                print("  no such tag: {0}".format(tag_name))
+                print("  no such image: {0}:{1}".format(image_name, tag_name))
+                continue
             tags_list = set([tag_name])
         else:
             all_tags_list = registry.list_tags(image_name)

--- a/registry.py
+++ b/registry.py
@@ -791,13 +791,21 @@ def main_loop(args):
         print("---------------------------------")
         print("Image: {0}".format(image_name))
 
-        all_tags_list = registry.list_tags(image_name)
+        # get tags from image name if any
+        if ":" in image_name:
+            (image_name, tag_name) = image_name.split(":")
+            all_tags_list = registry.list_tags(image_name)
+            if not tag_name in all_tags_list:
+                print("  no such tag: {0}".format(tag_name))
+            tags_list = set([tag_name])
+        else:
+            all_tags_list = registry.list_tags(image_name)
 
-        if not all_tags_list:
-            print("  no tags!")
-            continue
+            if not all_tags_list:
+                print("  no tags!")
+                continue
 
-        tags_list = get_tags(all_tags_list, image_name, args.tags_like)
+            tags_list = get_tags(all_tags_list, image_name, args.tags_like)
 
         # print(tags and optionally layers
         for tag in tags_list:


### PR DESCRIPTION
The help text showed (and still shows) the option to use IMAGE:TAG
for image, but in practice was trying to use this as the image name
itself. Update to explicitly handle this - if used then, other ways
of setting tags (e.g. --tags-like) are ignored. Still need to use
-n 0 for consistency.

This partly relates to #50.