### PR TITLE
Add --network=host when run by docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can download ready-made docker image with the script and all python dependen
 In this case, replace `registry.py` with `docker run --rm anoxis/registry-cli`
 in all commands below, e.g.
 ```
-    docker run --rm anoxis/registry-cli -r http://example.com:5000
+    docker run --network=host --rm anoxis/registry-cli -r http://example.com:5000
 ```
 
 Note: when you use the docker image and registry on the same computer (registry is on localhost), then due to internal network created by docker you have to link to the registry's network and refer registry container by its name, not localhost.


### PR DESCRIPTION
Fix Failed to establish a new connection when use docker and localhost

```
docker run --rm anoxis/registry-cli -r http://localhost:32000 --delete-all
Traceback (most recent call last):
  File "/registry.py", line 857, in <module>
    main_loop(args)
  File "/registry.py", line 776, in main_loop
    registry.auth_schemes = get_auth_schemes(registry,'/v2/_catalog')
  File "/registry.py", line 174, in get_auth_schemes
    try_oauth = requests.head('{0}{1}'.format(r.hostname,path), verify=not r.no_validate_ssl)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 104, in head
    return request('head', url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=32000): Max retries exceeded with url: /v2/_catalog (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fe6353e2d50>: Failed to establish a new connection: [Errno 111] Connection refused',))
```