### PR TITLE
More compact code for reading password

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -757,28 +757,12 @@ def main_loop(args):
         if args.login is None:
             print("Please provide -l when using -w")
             sys.exit(1)
-
-        if ':' in args.login:
-            (username, password) = args.login.split(':', 1)
-        else:
-            username = args.login
-
-        if sys.stdin.isatty():
-            # likely interactive usage
-            password = getpass()
-
-        else:
-            # allow password to be piped or redirected in
-            password = sys.stdin.read()
-
-            if len(password) == 0:
-                print("Password was not provided")
-                sys.exit(1)
-
-            if password[-(len(os.linesep)):] == os.linesep:
-                password = password[0:-(len(os.linesep))]
-
-        args.login = username + ':' + password
+        username = args.login.split(':', 1)[0]
+        password = getpass() if sys.stdin.isatty() else sys.stdin.read()
+        if not password:
+            print("Password was not provided")
+            sys.exit(1)
+        args.login = username + ':' + password.strip()
 
     registry = Registry.create(args.host, args.login, args.no_validate_ssl,
                                args.digest_method)


### PR DESCRIPTION
* Even if the user has entered `-w -l foo:bar`, python will ignore `bar` as a password and either read it with getpass() or read from stdin. 
* `"foo".split(':')[0]` is no different from `"foo:bar".split(':')[0]`
* regardless how a user gives password, python should check that the user has given password
* python can use `strip()` to eliminate possible end-of-line character

The only slightly open topic that I can figure out is whether python should `strip()` password before python validates that the user has given a password or give him the option to use some whitespace to give an empty password.