### PR TITLE
Fix test.py to reflect --plain

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -612,24 +612,24 @@ def delete_tags(
 # registry.delete_tag_layer(image_name, layer_digest, dry_run)
 
 
-def get_tags_like(args_tags_like, tags_list):
+def get_tags_like(args_tags_like, tags_list, plain):
     result = set()
     for tag_like in args_tags_like:
-        if not args.plain:
+        if not plain:
             print("tag like: {0}".format(tag_like))
         for tag in tags_list:
             if re.search(tag_like, tag):
-                if not args.plain:
+                if not plain:
                     print("Adding {0} to tags list".format(tag))
                 result.add(tag)
     return result
 
 
-def get_tags(all_tags_list, image_name, tags_like):
+def get_tags(all_tags_list, image_name, tags_like, plain):
     # check if there are args for special tags
     result = set()
     if tags_like:
-        result = get_tags_like(tags_like, all_tags_list)
+        result = get_tags_like(tags_like, all_tags_list, plain)
     else:
         result.update(all_tags_list)
 
@@ -694,7 +694,7 @@ def get_newer_tags(registry, image_name, hours, tags_list):
     return result
 
 
-def get_datetime_tags(registry, image_name, tags_list):
+def get_datetime_tags(registry, image_name, tags_list, plain):
     def newer(tag):
         image_config = registry.get_tag_config(image_name, tag)
         if image_config == []:
@@ -709,7 +709,7 @@ def get_datetime_tags(registry, image_name, tags_list):
             "datetime": parse(image_age).astimezone(tzutc())
         }
 
-    if not args.plain:
+    if not plain:
         print('---------------------------------')
     p = ThreadPool(4)
     result = list(x for x in p.map(newer, tags_list) if x)
@@ -810,7 +810,7 @@ def main_loop(args):
         if args.order_by_date:
             tags_list = get_ordered_tags(registry, image_name, all_tags_list, args.order_by_date)
         else:
-            tags_list = get_tags(all_tags_list, image_name, args.tags_like)
+            tags_list = get_tags(all_tags_list, image_name, args.tags_like, args.plain)
 
         # print(tags and optionally layers
         for tag in tags_list:

--- a/test.py
+++ b/test.py
@@ -231,18 +231,18 @@ class TestListTags(unittest.TestCase):
     def test_list_tags_like_various(self):
         tags_list = set(['FINAL_0.1', 'SNAPSHOT_0.1',
                          "0.1.SNAP", "1.0.0_FINAL"])
-        self.assertEqual(get_tags(tags_list, "", set(
-            ["FINAL"])), set(["FINAL_0.1", "1.0.0_FINAL"]))
-        self.assertEqual(get_tags(tags_list, "", set(
-            ["SNAPSHOT"])), set(['SNAPSHOT_0.1']))
-        self.assertEqual(get_tags(tags_list, "", set()),
-                         set(['FINAL_0.1', 'SNAPSHOT_0.1', "0.1.SNAP", "1.0.0_FINAL"]))
-        self.assertEqual(get_tags(tags_list, "", set(["ABSENT"])), set())
-
-        self.assertEqual(
-            get_tags(tags_list, "IMAGE:TAG00", ""), set(["TAG00"]))
-        self.assertEqual(get_tags(tags_list, "IMAGE:TAG00", set(
-            ["WILL_NOT_BE_CONSIDERED"])), set(["TAG00"]))
+        for plain in [True, False]:
+            self.assertEqual(get_tags(tags_list, "", set(
+                ["FINAL"]), plain), set(["FINAL_0.1", "1.0.0_FINAL"]))
+            self.assertEqual(get_tags(tags_list, "", set(
+                ["SNAPSHOT"]), plain), set(['SNAPSHOT_0.1']))
+            self.assertEqual(get_tags(tags_list, "", set(), plain),
+                            set(['FINAL_0.1', 'SNAPSHOT_0.1', "0.1.SNAP", "1.0.0_FINAL"]))
+            self.assertEqual(get_tags(tags_list, "", set(["ABSENT"]), plain), set())
+            self.assertEqual(
+                get_tags(tags_list, "IMAGE:TAG00", "", plain), set(["TAG00"]))
+            self.assertEqual(get_tags(tags_list, "IMAGE:TAG00", set(
+                ["WILL_NOT_BE_CONSIDERED"]), plain), set(["TAG00"]))
 
 
 class TestListDigest(unittest.TestCase):
@@ -760,17 +760,19 @@ class TestGetDatetimeTags(unittest.TestCase):
         self.registry.http.reset_return_value(200, "MOCK_DIGEST")
 
     def test_get_datetime_tags(self):
-        self.assertEqual(
-            get_datetime_tags(self.registry, "imagename", ["latest"]),
-            [{"tag": "latest", "datetime": datetime(2017, 12, 27, 12, 47, 33, 511765, tzinfo=tzutc())}]
-        )
+        for plain in [True, False]:
+            self.assertEqual(
+                get_datetime_tags(self.registry, "imagename", ["latest"], plain),
+                [{"tag": "latest", "datetime": datetime(2017, 12, 27, 12, 47, 33, 511765, tzinfo=tzutc())}]
+            )
 
     def test_get_non_utc_datetime_tags(self):
         self.registry.get_image_age.return_value = "2019-07-18T16:33:15.864962122+02:00"
-        self.assertEqual(
-            get_datetime_tags(self.registry, "imagename", ["latest"]),
-            [{"tag": "latest", "datetime": datetime(2019, 7, 18, 16, 33, 15, 864962, tzinfo=tzoffset(None, 7200))}]
-        )
+        for plain in [True, False]:
+            self.assertEqual(
+                get_datetime_tags(self.registry, "imagename", ["latest"], plain),
+                [{"tag": "latest", "datetime": datetime(2019, 7, 18, 16, 33, 15, 864962, tzinfo=tzoffset(None, 7200))}]
+            )
 
 
 class TestGetOrderedTags(unittest.TestCase):


### PR DESCRIPTION
test.py broke, when PR #109 was merged, because original PR assumed that we have global `args` variable.
I've simply added `plain` attribute to function calls, where we need `args.plain`and made test.py to reflect these changes.