### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\d'

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -133,7 +133,7 @@ def natural_keys(text):
     def __atoi(text):
         return int(text) if text.isdigit() else text
 
-    return [__atoi(c) for c in re.split('(\d+)', text)]
+    return [__atoi(c) for c in re.split(r'(\d+)', text)]
 
 
 def decode_base64(data):


### PR DESCRIPTION
I see the following warning when running `registry.py`:
```
registry.py:136: SyntaxWarning: invalid escape sequence '\d'
```

This PR marks the offending string as a [raw string literal](https://docs.python.org/3/reference/lexical_analysis.html#raw-strings) to tell Python the `\d` is not an escape sequence (like `\n`).